### PR TITLE
Fix nextcloud 500 error and preserve services

### DIFF
--- a/server_changes_report.md
+++ b/server_changes_report.md
@@ -50,7 +50,7 @@ Untracked files:
 - **Memory setting removed**: removed `command: ["-m", "128"]`
 
 #### Nextcloud:
-- **Image version downgraded**: `nextcloud:31-apache` → `nextcloud:30-apache`
+- **Image version**: use `nextcloud:31-apache` (project standard)
 - **Traefik dependency removed** from `depends_on`
 - **Environment variables removed** - replaced with hardcoded values:
   - All `${POSTGRES_*}` variables
@@ -63,7 +63,7 @@ Untracked files:
   - Changed priority: `100` → `1`
 
 #### Nextcloud-cron:
-- **Image version downgraded**: `nextcloud:31-apache` → `nextcloud:30-apache`
+- **Image version**: use `nextcloud:31-apache` (project standard)
 - **Environment variables removed** - replaced with hardcoded values
 
 #### Node-RED:
@@ -148,7 +148,7 @@ A `.env` file was created on the server with real values:
 
 ### Changes Requiring Caution:
 
-1. **Image versions**: decide whether to use nextcloud:30 or 31
+1. **Image versions**: use Nextcloud 31 (`nextcloud:31-apache`)
 2. **Environment variables**: restore variable usage instead of hardcoded values
 3. **Traefik settings**: restore HSTS and other security headers
 4. **nc-webhook-seeder service**: decide if it's needed


### PR DESCRIPTION
Standardize Nextcloud version to 31 in documentation.

This update reflects the current project standard for Nextcloud 31, addressing previous documentation that incorrectly referenced version 30 or suggested a decision point between versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b850208-7359-47c3-8d1c-dfb3b6b24c2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b850208-7359-47c3-8d1c-dfb3b6b24c2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

