### PR TITLE
Fix nextcloud login error on ncrag.voronkov.club

### DIFF
--- a/webhook_rabbitmq/appinfo/info.xml
+++ b/webhook_rabbitmq/appinfo/info.xml
@@ -13,7 +13,7 @@
   <bugs>https://example.com/issues</bugs>
   <dependencies>
     <php min-version="8.1"/>
-    <nextcloud min-version="30" max-version="30"/>
+    <nextcloud min-version="30" max-version="31"/>
   </dependencies>
   <settings>
     <admin>OCA\WebhookRabbitMQ\Settings\Admin</admin>


### PR DESCRIPTION
Extend `webhook_rabbitmq` app compatibility to Nextcloud 31 to fix 500 errors after upgrade.

The custom app was only declared compatible with Nextcloud 30, which likely caused it to be disabled or malfunction after the upgrade to Nextcloud 31, resulting in a 500 error on the main page.

---
<a href="https://cursor.com/background-agent?bcId=bc-16eb24fb-c52c-4075-ae6b-91ac0edbd977">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16eb24fb-c52c-4075-ae6b-91ac0edbd977">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

