### PR TITLE
Integrate webhook plugin into nextcloud build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Experimental RAG replacement for NextCloud and Talk
 - APIs: /docs/apis
 - Schemas: /docs/schemas
 - Phase Reports: /docs/reports/phase-template.md
+
+## Nextcloud customizations
+
+- Custom Nextcloud image is built from `services/nextcloud/Dockerfile`.
+- App `webhook_rabbitmq` is baked into the image and enabled via startup hook `services/nextcloud/hooks/10-config.sh`.
+- Configure the plugin via env variables in `docker-compose.yml` (prefixed `NC_webhook_rabbitmq_...`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,9 @@ services:
       - backend
 
   nextcloud:
-    image: nextcloud:31-apache
+    build:
+      context: ./
+      dockerfile: services/nextcloud/Dockerfile
     container_name: nextcloud
     depends_on:
       - db
@@ -78,6 +80,16 @@ services:
       REDIS_HOST_PORT: 6379
       MEMCACHED_HOST: memcached
       MEMCACHED_PORT: 11211
+      # Webhook RabbitMQ app env (read by hook and/or app)
+      NC_webhook_rabbitmq_enabled: ${NC_webhook_rabbitmq_enabled:-1}
+      NC_webhook_rabbitmq_host: ${NC_webhook_rabbitmq_host:-rabbitmq}
+      NC_webhook_rabbitmq_port: ${NC_webhook_rabbitmq_port:-5672}
+      NC_webhook_rabbitmq_user: ${NC_webhook_rabbitmq_user:-${RABBITMQ_USER:-ncrag}}
+      NC_webhook_rabbitmq_pass: ${NC_webhook_rabbitmq_pass:-${RABBITMQ_PASSWORD:-ncragpass}}
+      NC_webhook_rabbitmq_vhost: ${NC_webhook_rabbitmq_vhost:-${RABBITMQ_VHOST:-ncrag}}
+      NC_webhook_rabbitmq_exchange: ${NC_webhook_rabbitmq_exchange:-nextcloud.events}
+      NC_webhook_rabbitmq_exchange_type: ${NC_webhook_rabbitmq_exchange_type:-topic}
+      NC_webhook_rabbitmq_routing_prefix: ${NC_webhook_rabbitmq_routing_prefix:-nextcloud}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.nextcloud.middlewares=hsts"
@@ -89,12 +101,13 @@ services:
       - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
     volumes:
       - nextcloud_data:/var/www/html
-      - ./webhook_rabbitmq:/var/www/html/custom_apps/webhook_rabbitmq:rw
     networks:
       - backend
 
   nextcloud-cron:
-    image: nextcloud:31-apache
+    build:
+      context: ./
+      dockerfile: services/nextcloud/Dockerfile
     container_name: nextcloud-cron
     restart: unless-stopped
     depends_on:

--- a/services/nextcloud/Dockerfile
+++ b/services/nextcloud/Dockerfile
@@ -1,4 +1,21 @@
 FROM nextcloud:31-apache
-COPY hooks/10-config.sh /docker-entrypoint-hooks.d/before-starting/10-config.sh
-COPY zzzz-session.ini /usr/local/etc/php/conf.d/zzzz-session.ini
+
+# Install php-amqp extension required by the webhook_rabbitmq app
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends pkg-config libssl-dev librabbitmq-dev autoconf build-essential git; \
+    pecl install amqp; \
+    docker-php-ext-enable amqp; \
+    apt-get purge -y --auto-remove git autoconf build-essential pkg-config; \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy startup hook to enable and configure custom apps before Apache starts
+COPY services/nextcloud/hooks/10-config.sh /docker-entrypoint-hooks.d/before-starting/10-config.sh
 RUN chmod +x /docker-entrypoint-hooks.d/before-starting/10-config.sh
+
+# Bake the webhook_rabbitmq Nextcloud app into the image so it is always present
+# Use /usr/src/nextcloud/custom_apps so it is copied into the persistent volume on first run
+COPY --chown=www-data:www-data webhook_rabbitmq /usr/src/nextcloud/custom_apps/webhook_rabbitmq
+
+# PHP session tuning
+COPY services/nextcloud/zzzz-session.ini /usr/local/etc/php/conf.d/zzzz-session.ini

--- a/services/nextcloud/hooks/10-config.sh
+++ b/services/nextcloud/hooks/10-config.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# This hook runs before Nextcloud starts. It ensures our custom app is available,
+# fixes permissions, enables the app, and applies configuration from env vars.
+
+APP_ID="webhook_rabbitmq"
+NC_DIR="/var/www/html"
+APPS_DIR="$NC_DIR/custom_apps"
+SRC_DIR="/usr/src/nextcloud/custom_apps/$APP_ID"
+
+echo "[hook] Ensuring $APP_ID is present in $APPS_DIR"
+mkdir -p "$APPS_DIR"
+if [ -d "$SRC_DIR" ]; then
+  # Sync baked app into the persistent volume if missing or empty
+  if [ ! -d "$APPS_DIR/$APP_ID" ] || [ -z "$(ls -A "$APPS_DIR/$APP_ID" 2>/dev/null || true)" ]; then
+    echo "[hook] Copying $APP_ID from image to persistent apps dir"
+    cp -a "$SRC_DIR" "$APPS_DIR/"
+  fi
+fi
+
+chown -R www-data:www-data "$APPS_DIR" || true
+
+# Enable the app if available
+if [ -x "$NC_DIR/occ" ]; then
+  echo "[hook] Enabling app $APP_ID (if not already)"
+  runuser -u www-data -- php -d memory_limit=512M "$NC_DIR/occ" app:enable "$APP_ID" || true
+fi
+
+# Apply configuration from environment variables NC_webhook_rabbitmq_* if provided
+apply_cfg() {
+  local key="$1"; local val="$2"
+  if [ -n "${val}" ]; then
+    echo "[hook] Setting app config $key"
+    runuser -u www-data -- php "$NC_DIR/occ" config:app:set "$APP_ID" "$key" --value="$val" || true
+  fi
+}
+
+apply_cfg enabled "${NC_webhook_rabbitmq_enabled:-}"
+apply_cfg host "${NC_webhook_rabbitmq_host:-}"
+apply_cfg port "${NC_webhook_rabbitmq_port:-}"
+apply_cfg user "${NC_webhook_rabbitmq_user:-}"
+apply_cfg pass "${NC_webhook_rabbitmq_pass:-}"
+apply_cfg vhost "${NC_webhook_rabbitmq_vhost:-}"
+apply_cfg exchange "${NC_webhook_rabbitmq_exchange:-}"
+apply_cfg exchange_type "${NC_webhook_rabbitmq_exchange_type:-}"
+apply_cfg routing_prefix "${NC_webhook_rabbitmq_routing_prefix:-}"
+
+echo "[hook] $APP_ID configuration hook completed"
+


### PR DESCRIPTION
Integrate the `webhook_rabbitmq` Nextcloud plugin into the automated build and configure it via environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-159e9af6-09bf-474a-8b23-748daff8904a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-159e9af6-09bf-474a-8b23-748daff8904a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

