### PR TITLE
Fix rabbitmq authentication for nc-rag worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
     build: ./services/worker
     container_name: nc-worker
     environment:
-      - RABBITMQ_URL=amqp://ncrag-app:${RABBITMQ_APP_PASS}@rabbitmq:5672/ncrag
+      - RABBITMQ_URL=amqp://ncrag-app:${RABBITMQ_APP_PASS:-ncragapppass}@rabbitmq:5672/ncrag
       - RABBITMQ_QUEUE=events.files
       - NEXTCLOUD_URL=https://${NEXTCLOUD_DOMAIN:-ncrag.voronkov.club}
       - NEXTCLOUD_USER=${NEXTCLOUD_ADMIN_USER:-admin}


### PR DESCRIPTION
Add a default password to the worker's RabbitMQ URL to resolve 403 connection errors.

The `nc-worker` failed to connect to RabbitMQ with a 'username or password not allowed' error because the `RABBITMQ_APP_PASS` environment variable was likely undefined, leading to an empty password in the connection string. This change provides a fallback password (`ncragapppass`) that matches the pre-configured RabbitMQ user, ensuring successful authentication without disabling security.

---
<a href="https://cursor.com/background-agent?bcId=bc-64006d3e-88cc-4325-93c5-781615205d1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64006d3e-88cc-4325-93c5-781615205d1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

